### PR TITLE
[hotfix issue#6] fix path of manifest.properties

### DIFF
--- a/Autoloader.php
+++ b/Autoloader.php
@@ -5,7 +5,7 @@
         public static function registerClass($className)
         {
             //Business Logic here
-            $path = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'manifest.properties';
+            $path = __DIR__ . DIRECTORY_SEPARATOR . 'manifest.properties';
             if (file_exists($path) == FALSE) {
                 throw new RuntimeException("properties file not found on $path");
             } else {


### PR DESCRIPTION
by design manifest.properties must be in the same directory of adiutor. Autoloader try to find it in the parent directory. fix the path in the Autoloader class to read the file in the expected directory.